### PR TITLE
Fix GitHub capitalization

### DIFF
--- a/About.html
+++ b/About.html
@@ -224,7 +224,7 @@
                 </div>
                 <div class="pt-5 d-block d-md-flex">
                     <a class="me-4" href="https://www.linkedin.com/in/leonxdinh/" target="_blank">LinkedIn</a>
-                    <a class="me-4" href="https://github.com/kaider/Portfolio" target="_blank">Github</a>
+                    <a class="me-4" href="https://github.com/kaider/Portfolio" target="_blank">GitHub</a>
                     <a class="" href="https://www.artstation.com/kaazzeerr" target="_blank">ArtStation</a>
                 </div>
             </div>
@@ -238,7 +238,7 @@
                 <p class="text-center my-0 px-4">Copyright &copy; Leon Dinh <span id="currentYear"></span></p>
                 <div class="socialIcon">
                     <a href="https://www.linkedin.com/in/leonxdinh/" target="_blank" data-tool-tip="LinkedIn"> <img src="./assets/img/Logo_LinkedIn.png" alt="LinkedIn"></a>
-                    <a href="https://github.com/kaider/" target="_blank" data-tool-tip="Github Repo"> <img src="./assets/img/Logo_GitHub.png" alt="Github"></a>
+                    <a href="https://github.com/kaider/" target="_blank" data-tool-tip="GitHub Repo"> <img src="./assets/img/Logo_GitHub.png" alt="GitHub"></a>
                     <a href="https://www.artstation.com/kaazzeerr" target="_blank" data-tool-tip="ArtStation"> <img src="./assets/img/Logo_ArtStation.png" alt="ArtStation"></a>
                 </div>
             </div>

--- a/CaseStudies/UX_AFA.html
+++ b/CaseStudies/UX_AFA.html
@@ -557,7 +557,7 @@
                 <p class="text-center my-0 px-4">Copyright &copy; Leon Dinh <span id="currentYear"></span></p>
                 <div class="socialIcon">
                     <a href="https://www.linkedin.com/in/leonxdinh/" target="_blank" data-tool-tip="LinkedIn"> <img src="../assets/img/Logo_LinkedIn.png" alt="LinkedIn"></a>
-                    <a href="https://github.com/kaider/Portfolio" target="_blank" data-tool-tip="Github Repo"> <img src="../assets/img/Logo_GitHub.png" alt="LinkedIn"></a>
+                    <a href="https://github.com/kaider/Portfolio" target="_blank" data-tool-tip="GitHub Repo"> <img src="../assets/img/Logo_GitHub.png" alt="GitHub"></a>
                     <a href="https://www.artstation.com/kaazzeerr" target="_blank" data-tool-tip="ArtStation"> <img src="../assets/img/Logo_ArtStation.png" alt="ArtStation"></a>
                 </div>
             </div>

--- a/CaseStudies/UX_CW.html
+++ b/CaseStudies/UX_CW.html
@@ -470,7 +470,7 @@
                 <p class="text-center my-0 px-4">Copyright &copy; Leon Dinh <span id="currentYear"></span></p>
                 <div class="socialIcon">
                     <a href="https://www.linkedin.com/in/leonxdinh/" target="_blank" data-tool-tip="LinkedIn"> <img src="../assets/img/Logo_LinkedIn.png" alt="LinkedIn"></a>
-                    <a href="https://github.com/kaider/Portfolio" target="_blank" data-tool-tip="Github Repo"> <img src="../assets/img/Logo_GitHub.png" alt="LinkedIn"></a>
+                    <a href="https://github.com/kaider/Portfolio" target="_blank" data-tool-tip="GitHub Repo"> <img src="../assets/img/Logo_GitHub.png" alt="GitHub"></a>
                     <a href="https://www.artstation.com/kaazzeerr" target="_blank" data-tool-tip="ArtStation"> <img src="../assets/img/Logo_ArtStation.png" alt="ArtStation"></a>
                 </div>
             </div>

--- a/CaseStudies/UX_TD.html
+++ b/CaseStudies/UX_TD.html
@@ -493,7 +493,7 @@
                 <p class="text-center my-0 px-4">Copyright &copy; Leon Dinh <span id="currentYear"></span></p>
                 <div class="socialIcon">
                     <a href="https://www.linkedin.com/in/leonxdinh/" target="_blank" data-tool-tip="LinkedIn"> <img src="../assets/img/Logo_LinkedIn.png" alt="LinkedIn"></a>
-                    <a href="https://github.com/kaider/Portfolio" target="_blank" data-tool-tip="Github Repo"> <img src="../assets/img/Logo_GitHub.png" alt="LinkedIn"></a>
+                    <a href="https://github.com/kaider/Portfolio" target="_blank" data-tool-tip="GitHub Repo"> <img src="../assets/img/Logo_GitHub.png" alt="GitHub"></a>
                     <a href="https://www.artstation.com/kaazzeerr" target="_blank" data-tool-tip="ArtStation"> <img src="../assets/img/Logo_ArtStation.png" alt="ArtStation"></a>
                 </div>
             </div>

--- a/CaseStudies/UX_VTP.html
+++ b/CaseStudies/UX_VTP.html
@@ -329,7 +329,7 @@
                 <p class="text-center my-0 px-4">Copyright &copy; Leon Dinh <span id="currentYear"></span></p>
                 <div class="socialIcon">
                     <a href="https://www.linkedin.com/in/leonxdinh/" target="_blank" data-tool-tip="LinkedIn"> <img src="../assets/img/Logo_LinkedIn.png" alt="LinkedIn"></a>
-                    <a href="https://github.com/kaider/Portfolio" target="_blank" data-tool-tip="Github Repo"> <img src="../assets/img/Logo_GitHub.png" alt="LinkedIn"></a>
+                    <a href="https://github.com/kaider/Portfolio" target="_blank" data-tool-tip="GitHub Repo"> <img src="../assets/img/Logo_GitHub.png" alt="GitHub"></a>
                     <a href="https://www.artstation.com/kaazzeerr" target="_blank" data-tool-tip="ArtStation"> <img src="../assets/img/Logo_ArtStation.png" alt="ArtStation"></a>
                 </div>
             </div>

--- a/index.html
+++ b/index.html
@@ -186,7 +186,7 @@
                             <p>UX/UI</p>
                             <p>Research</p>
                             <p>Design System</p>
-                            <p>Github</p>
+                            <p>GitHub</p>
                         </div>
                         <a class="hvr-sweep UXCaseButton" href="./CaseStudies/UX_CW.html">View Case Study</a>
                     </div>
@@ -504,7 +504,7 @@
                 <p class="text-center my-0 px-4">Copyright &copy; Leon Dinh <span id="currentYear"></span></p>
                 <div class="socialIcon">
                     <a href="https://www.linkedin.com/in/leonxdinh/" target="_blank" data-tool-tip="LinkedIn"> <img src="./assets/img/Logo_LinkedIn.png" alt="LinkedIn"></a>
-                    <a href="https://github.com/kaider/Portfolio" target="_blank" data-tool-tip="Github Repo"> <img src="./assets/img/Logo_GitHub.png" alt="LinkedIn"></a>
+                    <a href="https://github.com/kaider/Portfolio" target="_blank" data-tool-tip="GitHub Repo"> <img src="./assets/img/Logo_GitHub.png" alt="GitHub"></a>
                     <a href="https://www.artstation.com/kaazzeerr" target="_blank" data-tool-tip="ArtStation"> <img src="./assets/img/Logo_ArtStation.png" alt="ArtStation"></a>
                 </div>
             </div>

--- a/js/scripts.js
+++ b/js/scripts.js
@@ -75,7 +75,6 @@ window.addEventListener('scroll', function(){
 
 // scroller bar responsive
 const sections = document.querySelectorAll('section');
-console.log(sections);
 const scroller = document.querySelectorAll('.scrollerBtn');
 
 const sectionWatcherCallback = (sections, sectionWatcher) => {
@@ -118,14 +117,14 @@ const appearOptions = {
 
 const appearOnScroll = new IntersectionObserver(function(
     entries,
-    appearOnScroll
+    observer
 ) {
     entries.forEach(entry => {
         if (!entry.isIntersecting) {
             return;
         } else {
             entry.target.classList.add('appear');
-            appearOnScroll.unobserve(entry.target);
+            observer.unobserve(entry.target);
         }
     });
 }, appearOptions);


### PR DESCRIPTION
## Summary
- standardize GitHub capitalization in footer tooltip text and labels
- correct GitHub spelling in About page contact links
- remove leftover debug logging and rename callback parameter for clarity

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_68701ea4755483238746070369899b3a