### PR TITLE
Add Jest tests for activeSectionHandler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/README.md
+++ b/README.md
@@ -11,3 +11,9 @@ https://kaider.github.io/Portfolio
 5. Clean up **In Progress**
 6. Migrate keyboard write-ups to the website
 7. React.JS
+
+## Running Tests
+
+1. Install dependencies using `npm install`.
+2. Execute the test suite with `npm test`.
+

--- a/js/activeSectionHandler.js
+++ b/js/activeSectionHandler.js
@@ -1,0 +1,16 @@
+function activeSectionHandler(currentSectionID) {
+    const scroller = document.querySelectorAll('.scrollerBtn');
+    scroller.forEach(link => {
+        if (link.dataset.section === currentSectionID) {
+            link.classList.add('scrollerActive');
+        } else {
+            link.classList.remove('scrollerActive');
+        }
+    });
+}
+
+if (typeof module !== 'undefined') {
+    module.exports = activeSectionHandler;
+} else {
+    window.activeSectionHandler = activeSectionHandler;
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "portfolio",
+  "version": "1.0.0",
+  "description": "Portfolio project",
+  "main": "index.js",
+  "scripts": {
+    "test": "jest"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "jest": {},
+  "devDependencies": {
+    "jest": "^29.6.2"
+  }
+}

--- a/tests/scripts.test.js
+++ b/tests/scripts.test.js
@@ -1,0 +1,26 @@
+const { JSDOM } = require('jsdom');
+const activeSectionHandler = require('../js/activeSectionHandler');
+
+describe('activeSectionHandler', () => {
+  let dom;
+
+  beforeEach(() => {
+    dom = new JSDOM(`
+      <div class="scrollerBtn" data-section="one"></div>
+      <div class="scrollerBtn" data-section="two"></div>
+    `);
+    global.document = dom.window.document;
+  });
+
+  afterEach(() => {
+    dom.window.close();
+    delete global.document;
+  });
+
+  test('sets scrollerActive class on matching element', () => {
+    const buttons = global.document.querySelectorAll('.scrollerBtn');
+    activeSectionHandler('two');
+    expect(buttons[1].classList.contains('scrollerActive')).toBe(true);
+    expect(buttons[0].classList.contains('scrollerActive')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- add basic Jest setup via package.json and .gitignore
- implement `activeSectionHandler` as testable module
- create unit test for the handler
- document test execution in README

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68702c19840c832380f9ebe3323614c2